### PR TITLE
chore: Add explicit npm publish configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,5 @@
   "bugs": {
     "url": "https://github.com/hongchenme/ms-email-mcp-server/issues"
   },
-  "homepage": "https://github.com/hongchenme/ms-email-mcp-server#readme" 
+  "homepage": "https://github.com/hongchenme/ms-email-mcp-server#readme"
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "author": "Hong Chen",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "tag": "latest"
   },
   "dependencies": {
     "@azure/msal-node": "^2.1.0",
@@ -81,5 +83,5 @@
   "bugs": {
     "url": "https://github.com/hongchenme/ms-email-mcp-server/issues"
   },
-  "homepage": "https://github.com/hongchenme/ms-email-mcp-server#readme"
+  "homepage": "https://github.com/hongchenme/ms-email-mcp-server#readme" 
 }


### PR DESCRIPTION
- Added registry URL to publishConfig for explicit npm registry
- Added tag "latest" to publishConfig for default npm tag
- Ensures package always publishes to correct registry with proper tag

🤖 Generated with [Claude Code](https://claude.ai/code)