### PR TITLE
fix: Correct NPM_TOKEN secret name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.npm_token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Changed npm_token to NPM_TOKEN to match GitHub secrets convention
- Ensures semantic-release can properly authenticate with npm registry

🤖 Generated with [Claude Code](https://claude.ai/code)