### PR TITLE
fix: Add redundant token environment variables for maximum compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,8 +100,10 @@ jobs:
 
       - name: Publish to NPM
         env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
           npm publish --access public
-          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,6 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Added both GITHUB_TOKEN and GH_TOKEN for GitHub authentication
- Added both NODE_AUTH_TOKEN and NPM_TOKEN for npm authentication
- Ensures compatibility with different semantic-release plugin versions
- Provides fallback options for authentication tokens

This redundancy ensures the workflows work regardless of which environment variable names the various tools expect.

🤖 Generated with [Claude Code](https://claude.ai/code)